### PR TITLE
HOFF-774: Update boilerplate code with DevOps setup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ environment:
   BRANCH_ENV: sas-hof-boilerplate-branch
   PRODUCTION_URL: www.hof-boilerplate.homeoffice.gov.uk
   IMAGE_URL: quay.io/ukhomeofficedigital
-  IMAGE_REPO: hof-boilerplate
+  IMAGE_REPO: sas/hof-boilerplate
   GIT_REPO: UKHomeOffice/hof-skeleton
   HOF_CONFIG: hof-services-config/Hof_Boilerplate
   NON_PROD_AVAILABILITY: Mon-Sun 08:00-23:00 Europe/London
@@ -25,7 +25,7 @@ trigger:
 
 linting: &linting
   pull: if-not-exists
-  image: node:lts
+  image: node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
   environment:
     NOTIFY_STUB: true
   commands:
@@ -33,7 +33,7 @@ linting: &linting
 
 unit_tests: &unit_tests
   pull: if-not-exists
-  image: node:lts
+  image: node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
   environment:
     NOTIFY_STUB: true
   commands:
@@ -56,9 +56,27 @@ steps:
         - feature/*
       event: [push, pull_request]
 
+  # Trivy Security Scannner for scanning OS related vulnerabilities in Base image of Dockerfile
+  - name: scan_image_os
+    pull: always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+    environment:
+      IMAGE_NAME: node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
+      SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+      SEVERITY: MEDIUM,HIGH,CRITICAL  --dependency-tree
+      FAIL_ON_DETECTION: false
+      IGNORE_UNFIXED: false
+      ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
+    when:
+      event: [push, pull_request]
+
   - name: setup_deploy
     pull: if-not-exists
-    image: node:lts
+    image: node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
     environment:
       NOTIFY_STUB: true
     commands:
@@ -98,23 +116,26 @@ steps:
       branch: master
       event: [push, pull_request]
 
-  - name: image_to_quay
-    pull: if-not-exists
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-    environment:
-      DOCKER_PASSWORD:
-        from_secret: DOCKER_PASSWORD
-    commands:
-    - docker login -u="ukhomeofficedigital+asc_robot" -p=$${DOCKER_PASSWORD} quay.io
-    - docker tag $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_COMMIT_SHA}
-    - docker push $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_COMMIT_SHA}
+  - name: image_to_ecr
+    image: plugins/ecr
+    settings:
+      access_key:
+        from_secret: aws_access_key_id
+      secret_key:
+        from_secret: aws_secret_access_key
+      region: eu-west-2
+      repo: sas/hof-boilerplate
+      registry: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
+      tags:
+        - latest_${DRONE_BRANCH}
+        - ${DRONE_COMMIT_SHA}
     when:
       branch: master
       event: [push, pull_request]
 
 
-  # Trivy Security Scannner
-  - name: scan-image
+  # Trivy Security Scannner for scanning nodejs packages in Yarn
+  - name: scan_node_packages
     pull: always
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     resources:
@@ -123,17 +144,15 @@ steps:
         memory: 1024Mi
     environment:
       IMAGE_NAME: additional-security-checks:${DRONE_COMMIT_SHA}
-      SEVERITY: MEDIUM,HIGH,CRITICAL
+      SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+      SEVERITY: MEDIUM,HIGH,CRITICAL  --dependency-tree
       FAIL_ON_DETECTION: false
-      IGNORE_UNFIXED: true
-      ALLOW_CVE_LIST_FILE: hof-services-config/Additional_Security_Checks/trivy-cve-exceptions.txt
+      IGNORE_UNFIXED: false
+      ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
-      event:
-      - pull_request
-      - push
-      - tag
+      event: [push, pull_request]
 
-  # Deploy to pull request UAT environment
+  # Deploy with pull request to Branch environment
   - name: deploy_to_branch
     pull: if-not-exists
     image: quay.io/ukhomeofficedigital/kd:v1.14.0
@@ -150,7 +169,7 @@ steps:
 
   - name: setup_branch
     pull: if-not-exists
-    image: node:lts
+    image: node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
     environment:
       NOTIFY_STUB: true
     commands:
@@ -330,53 +349,79 @@ steps:
       cron: security_scans
       event: cron
 
-  - name: cron_trivy_scan
+  - name: cron_trivy_scan_node_packages
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     pull: always
     environment:
-      IMAGE_NAME: additional-security-checks:${DRONE_COMMIT_SHA}
-      SEVERITY: MEDIUM,HIGH,CRITICAL
-      FAIL_ON_DETECTION: false
-      IGNORE_UNFIXED: true
-      ALLOW_CVE_LIST_FILE: hof-services-config/Additional_Security_Checks/trivy-cve-exceptions.txt
+        IMAGE_NAME: additional-security-checks:${DRONE_COMMIT_SHA}
+        SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+        SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
+        FAIL_ON_DETECTION: true
+        IGNORE_UNFIXED: false
+        ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
       cron: security_scans
       event: cron
 
-  # Slack notification upon a CRON job fail
-  - name: cron_notify_slack_tear_down_pr_envs
-    pull: if-not-exists
-    image: plugins/slack
+  - name: cron_trivy_scan_image_os
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    pull: always
+    environment:
+        IMAGE_NAME: node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
+        SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+        SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
+        FAIL_ON_DETECTION: true
+        IGNORE_UNFIXED: false
+        ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
+    when:
+      cron: security_scans
+      event: cron
+
+    image: plugins/slack:1.4.1
     settings:
-      channel: sas-build
+      channel: sas-hof-build-notify
       failure: ignore
-      icon_url: https://readme.drone.io/0.5/logo_dark.svg
-      icon.url: https://readme.drone.io/0.5/logo_dark.svg
-      template: "CRON Job {{build.deployTo}} of ASC has {{build.status}} - <{{build.link}}|#{{build.number}}> {{#success build.status}}\n  :thumbsup: :thumbsup: :thumbsup:\n{{else}}\n  :x: :x: :x:\n{{/success}} Author: {{build.author}}\n\nDuration: {{since job.started}}\n\nJob: <{{build.link}}|#{{build.number}}>\n\nCommit: {{build.commit}}\n"
-      username: Drone
+      template: >
+          :x: Build for cron tear down pr envs failed. 
+
+          Cron job failed to tear the deployments in Branch Env. Please use the information below to fix pipeline.
+
+          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}>
+          
+          *Build Link:* <{{build.link}}|View Build Details> 
       webhook:
-        from_secret: slack_webhook
+        from_secret: slack_sas_hof_build_notify_webhook
     when:
       cron: tear_down_pr_envs
       event: cron
-      status: failure
+      status: [ failure ]
 
   - name: cron_notify_slack_security_scans
     pull: if-not-exists
-    image: plugins/slack
+    image: plugins/slack:1.4.1
     settings:
-      channel: sas-build
+      channel: sas-hof-security
       failure: ignore
-      icon_url: https://readme.drone.io/0.5/logo_dark.svg
-      icon.url: https://readme.drone.io/0.5/logo_dark.svg
-      template: "CRON Job {{build.deployTo}} of ASC has {{build.status}} - <{{build.link}}|#{{build.number}}> {{#success build.status}}\n  :thumbsup: :thumbsup: :thumbsup:\n{{else}}\n  :x: :x: :x:\n{{/success}} Author: {{build.author}}\n\nDuration: {{since job.started}}\n\nJob: <{{build.link}}|#{{build.number}}>\n\nCommit: {{build.commit}}\n"
-      username: Drone
+      template: >
+          :x: Build for cron security scans failed. 
+
+          Trivy has detected vulnerabilities. As a result, the build has failed. Please prioritize reviewing and addressing this issue.
+
+          *Repository:*  <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> 
+
+          *Branch:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+
+          *Build Link:* <{{build.link}}|View Build Details>
+
+          *Commit:* <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+
+          *Author:* <https://github.com/{{ build.author }}|{{ build.author }}>
       webhook:
-        from_secret: slack_webhook
+        from_secret: slack_sas_hof_security_webhook
     when:
       cron: security_scans
       event: cron
-      status: failure
+      status: [ failure ]
 
 services:
   - name: docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Accept a build Argument named BASE_IMAGE
+FROM node:20.15.0-alpine3.20@sha256:24c14a8a192a6e81d0942929a344f7a4bdf0db8e3b3c77d64a5eb8a4b0c759b7
+USER root
+
+# Update packages as a result of Anchore security vulnerability checks
+RUN apk update && \
+    apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2
+
+
+# Setup nodejs group & nodejs user
+RUN addgroup --system nodejs --gid 998 && \
+    adduser --system nodejs --uid 999 --home /app/ && \
+    chown -R 999:998 /app/
+
+USER 999
+
+WORKDIR /app
+
+COPY --chown=999:998 . /app
+
+RUN yarn install --frozen-lockfile --production --ignore-optional && \
+    yarn run postinstall
+
+HEALTHCHECK --interval=5m --timeout=3s \
+ CMD curl --fail http://localhost:8080 || exit 1
+
+CMD ["sh", "/app/run.sh"]
+
+EXPOSE 8080

--- a/kube/app/ingress-external.yml
+++ b/kube/app/ingress-external.yml
@@ -13,10 +13,9 @@ spec:
   tls:
     - hosts:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-        - {{ .DRONE_BUILD_NUMBER }}.asc-branch.homeoffice.gov.uk
-        - asc-{{ .DRONE_SOURCE_BRANCH }}.asc-branch.homeoffice.gov.uk
+        - {{.APP_NAME}}-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-        - asc.uat.sas-notprod.homeoffice.gov.uk
+        - {{.APP_NAME}}.uat.sas-notprod.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}
         - {{ .PRODUCTION_URL }}
       {{ end }}
@@ -27,7 +26,7 @@ spec:
       {{ end }}
   rules:
     {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-    - host: asc-{{ .DRONE_SOURCE_BRANCH }}.asc-branch.homeoffice.gov.uk
+    - host: {{.APP_NAME}}-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     - host: asc.uat.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .PROD_ENV }}

--- a/kube/certs/certificate-external.yml
+++ b/kube/certs/certificate-external.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     cert-manager.io/solver: route53
 spec:
-  commonName: "*.asc-branch.homeoffice.gov.uk"
+  commonName: "*.branch.sas-notprod.homeoffice.gov.uk"
   dnsNames:
-  - "*.asc-branch.homeoffice.gov.uk"
+  - "*.branch.sas-notprod.homeoffice.gov.uk"
   issuerRef:
     kind: ClusterIssuer
-    name: letsencrypt-prod
+    name: letsencrypt-staging
   secretName: branch-tls-external

--- a/kube/certs/certificate-internal.yml
+++ b/kube/certs/certificate-internal.yml
@@ -5,10 +5,10 @@ metadata:
   labels:
     cert-manager.io/solver: route53
 spec:
-  commonName: "*.internal.asc-branch.homeoffice.gov.uk"
+  commonName: "*.internal.branch.sas-notprod.homeoffice.gov.uk"
   dnsNames:
-  - "*.internal.asc-branch.homeoffice.gov.uk"
+  - "*.internal.branch.sas-notprod.homeoffice.gov.uk"
   issuerRef:
     kind: ClusterIssuer
-    name: letsencrypt-prod
+    name: letsencrypt-staging
   secretName: branch-tls-internal

--- a/kube/hof-rds-api/ingress.yml
+++ b/kube/hof-rds-api/ingress.yml
@@ -19,7 +19,7 @@ spec:
       {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
         - data-service.uat.sas-notprod.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-        - data-service-{{ .DRONE_SOURCE_BRANCH }}.asc-branch.homeoffice.gov.uk
+        - data-service-{{ .DRONE_SOURCE_BRANCH }}.asc.branch.sas-notprod.homeoffice.gov.uk
       {{ end }}
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
       secretName: branch-tls-external
@@ -34,7 +34,7 @@ spec:
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
     - host: data-service.uat.sas-notprod.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-    - host: data-service-{{ .DRONE_SOURCE_BRANCH }}.asc-branch.homeoffice.gov.uk
+    - host: data-service-{{ .DRONE_SOURCE_BRANCH }}.asc.branch.sas-notprod.homeoffice.gov.uk
     {{ end }}
       http:
         paths:


### PR DESCRIPTION
What?

DevOps setup has been changing time to time. We have used new feature on different services. for eg: ACRS uses ECR image repo. COA has the fixed Cron Jobs.


Why?
* We have recently started seeing rate limiting issue. One of the reason is using letsencrypt-prod cluster issuer for all env. Due to the limit of issuing 50 certs a week. This limit gets exceeded quite often forcing us to use zerossl-production. We can avoid this situation by using letsencrypt-staging in lower env. This is advised by ACP team
* I have updated ingress url. It would be easier for ACP to add and for us to request the URLs with wild cards. ACP also suggests us using  "*.branch.sas-notprod.homeoffice.gov.uk" for file vault, data service, and app front end ingress.
*  Trivy step to scan Base OS image vulnerabilties and Node packages as discussed in one of the Meetings. and the path is set to a global CVE exception file. Now also reports with a dependency tree.
* Latest Node Image tested on COA and has no high and medium vulnerabilities

HOW?
Necessary files have been updated as explained in WHY?


Anything Else?
Our team is not sure of using the Redis secret? Some services using session-secret some use redis secret. But there is no reference of the secret being used .
File vault and Nginx-proxy contaners are using same ports. this could split the incoming traffic between both containers. We have notice it in COA. and Developer deleted the container ports. 
I am planning to use Yaml Anchors and alias for few steps in upcoming projects. Once tested. I will add to this repo.
For IMA and ACRS we used internal ingress for dataservice end point. As this is backend service.