### PR TITLE
HOFF-113: added .gitkeep to track empty views folder. Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 The purpose of this project is to provide a very simple project which contains the latest version of the HOF framework, and necessary dependencies to get started with building a HOF form. 
 
+## Pre-Requirements
+
+Using this project, and therefore the HOF framework, requires [Redis](https://redis.io/). Instructions on [how to install redis on OSX](https://medium.com/@petehouston/install-and-config-redis-on-mac-os-x-via-homebrew-eb8df9a4f298#.jcwwhv7oz).
+
+Further details of HOF requirements can be found [here](https://ukhomeofficeforms.github.io/hof-guide/HOF_Framework/1-getting-started).
+
+https://ukhomeofficeforms.github.io/hof-guide/HOF_Framework/1-getting-started
+
 ## Getting Started
 
 1. Clone this repo `git clone git@github.com:UKHomeOfficeForms/hof-skeleton.git` into a destination folder of your chosing. 


### PR DESCRIPTION
## What? 

Added .gitkeep to track empty views folder. Updated README to contain details on redis

## Why? 

- HOF requires Redis, so the README in the skeleton app should detail this
- HOF framework requires a `views` folder to work properly, even if no content exists in that folder.

## How? 

- Updated the README to contain redis details
- Added a `.gitkeep` file in the `views` folder to track the empty folder.

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
